### PR TITLE
Package-lock sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
-        "@reach-sh/stdlib": "^0.1.10-rc.6"
+        "@reach-sh/stdlib": "0.1.10-rc.6"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.11",


### PR DESCRIPTION
`package-lock` was still showing `^0.1.10-rc.6`; updating fixed it. This will prevent others from generating this file as a change.