### PR TITLE
SWAP-928 - Pool Listener seek-now

### DIFF
--- a/cli/runAnnouncerTest.mjs
+++ b/cli/runAnnouncerTest.mjs
@@ -1,5 +1,14 @@
 import { subscribeToPoolStream, getPoolAnnouncer } from "@reach-sh/humble-sdk";
-import { exitWithMsgs, Blue, Red, Yellow, iout, Green } from "./utils.mjs";
+import { yesno } from "@reach-sh/stdlib/ask.mjs";
+import {
+  exitWithMsgs,
+  Blue,
+  Red,
+  Yellow,
+  iout,
+  Green,
+  answerOrDie
+} from "./utils.mjs";
 
 let exitTimeout;
 const LIMIT = 10;
@@ -7,19 +16,21 @@ const TIMEOUT = 15;
 const pools = new Set();
 
 /** Attach to pool announcer and list a subset of pools */
-export function runAnnouncerTest(acc) {
+export async function runAnnouncerTest(acc) {
   console.clear();
   Blue(`Running ANNOUNCER ${getPoolAnnouncer()}`);
   Yellow(`Attaching pool listener ...`);
+  const seekNow = await answerOrDie("Start from now? (y/n)", yesno);
+
   subscribeToPoolStream(acc, {
-    includeTokens: true,
     onPoolReceived: (msg) => {
       Blue("* Received [poolId, tokenA, tokenB]");
       Green(`\t ${JSON.stringify(msg)}`);
       resetTimer();
     },
     onPoolFetched,
-    includeTokens: true,
+    seekNow,
+    includeTokens: true
   });
   Blue(`Listening for up to ${LIMIT} pools.`);
   resetTimer();


### PR DESCRIPTION
* enables seek-now on pool-announcer

### Testing
[ Optional: change `initHumbleSDK` in `cli/index.mjs` to `initHumbleSDK({ network: "MainNet" })` if you want to test with mainnet ]

* `npm run build` in the root (don't forget to `npm i` if you haven't)
* `cd cli/ && npm i` (to make sure you have the files you just built)
* `npm run test` and enter `1` to **List Pools**. You will want to do this twice:
  * Once with `n` to the **Start from now?** question (normal run: returns pools)
  * Once with `y` to the **Start from now?** question (expected: no results until script times out)