### PR TITLE
v2.1.0-beta.8

### DIFF
--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -25,10 +25,15 @@ import { runCreateFarmTest } from "./runCreateFarmTest.mjs";
 import { runFetchFarmTest } from "./runFetchFarmTest.mjs";
 import { runCheckRewardsTest } from "./runCheckRewardsTest.mjs";
 import { runAnnounceFarmTest } from "./runAnnounceFarmTest.mjs";
+import dotenv from "dotenv";
+
+dotenv.config({ path: "./.env" });
 
 // init SDK
+const TK = process.env.ALGONODE_TOKEN;
 initHumbleSDK({
   network: "TestNet",
+  providerEnv: { ALGO_TOKEN: TK, ALGO_INDEXER_TOKEN: TK },
   customFarmAnnouncerAddress: 100474119,
   customAnnouncerId: 93443561,
   customAnnouncerAddress:

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -21,7 +21,7 @@
     },
     "..": {
       "name": "@reach-sh/humble-sdk",
-      "version": "2.1.0-beta.6",
+      "version": "2.1.0-beta.7",
       "license": "ISC",
       "dependencies": {
         "@reach-sh/stdlib": "0.1.10-rc.6"
@@ -30,7 +30,6 @@
         "@babel/preset-env": "^7.16.11",
         "@babel/preset-typescript": "^7.16.7",
         "@types/await-timeout": "^0.3.1",
-        "@types/dotenv": "^8.2.0",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.45",
         "jest": "^27.5.1",
@@ -3452,7 +3451,6 @@
         "@babel/preset-typescript": "^7.16.7",
         "@reach-sh/stdlib": "0.1.10-rc.6",
         "@types/await-timeout": "^0.3.1",
-        "@types/dotenv": "^8.2.0",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.45",
         "jest": "^27.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@babel/preset-env": "^7.16.11",
         "@babel/preset-typescript": "^7.16.7",
         "@types/await-timeout": "^0.3.1",
-        "@types/dotenv": "^8.2.0",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.45",
         "jest": "^27.5.1",
@@ -3210,16 +3209,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "node_modules/@types/dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-ylSC9GhfRH7m1EUXBXofhgx4lUWmFeQDINW5oLuS+gxWdfUeW4zJdeVTYVkexEW+e2VUvlZR2kGnGGipAWR7kw==",
-      "deprecated": "This is a stub types definition. dotenv provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "dotenv": "*"
-      }
-    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -4600,15 +4589,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/drbg.js": {
@@ -11995,15 +11975,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-ylSC9GhfRH7m1EUXBXofhgx4lUWmFeQDINW5oLuS+gxWdfUeW4zJdeVTYVkexEW+e2VUvlZR2kGnGGipAWR7kw==",
-      "dev": true,
-      "requires": {
-        "dotenv": "*"
-      }
-    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -13130,12 +13101,6 @@
           "dev": true
         }
       }
-    },
-    "dotenv": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
-      "dev": true
     },
     "drbg.js": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reach-sh/humble-sdk",
-  "version": "2.1.0-beta.7",
+  "version": "2.1.0-beta.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reach-sh/humble-sdk",
-      "version": "2.1.0-beta.7",
+      "version": "2.1.0-beta.8",
       "license": "ISC",
       "dependencies": {
         "@reach-sh/stdlib": "0.1.10-rc.6"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-typescript": "^7.16.7",
     "@types/await-timeout": "^0.3.1",
-    "@types/dotenv": "^8.2.0",
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.45",
     "jest": "^27.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reach-sh/humble-sdk",
-  "version": "2.1.0-beta.7",
+  "version": "2.1.0-beta.8",
   "description": "A Javascript library for interacting with the HumbleSwap DEx",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,5 @@
 import { loadStdlib } from "@reach-sh/stdlib";
 import { loadReach, NetworkProvider, SDKOpts } from "./reach-helpers";
-import dotenv from "dotenv";
-import { join } from "path";
-
-const dotenvPath = join(__dirname, `../.env`)
-dotenv.config({ path: dotenvPath })
 
 // CONSTANTS
 import {

--- a/src/reach-helpers/index.ts
+++ b/src/reach-helpers/index.ts
@@ -102,20 +102,16 @@ function buildProviderEnv(
   const network = provider.toLowerCase();
   const server = `https://${network}-api.${domain}`;
   const indexer = `https://${network}-idx.${domain}`;
-  const AGN_TOKEN = process.env.ALGONODE_TOKEN;
-  if (!AGN_TOKEN) throw new Error("AlgoNode token not found")
-  const env = {
+  const env: T.AlgoEnvOverride = {
     ALGO_SERVER: server,
     ALGO_PORT: "",
     ALGO_INDEXER_SERVER: indexer,
     ALGO_INDEXER_PORT: "",
     REACH_ISOLATED_NETWORK: "no",
-    ALGO_TOKEN: AGN_TOKEN,
-    ALGO_INDEXER_TOKEN: AGN_TOKEN,
     ...overrides
   };
 
-  return env as T.AlgoEnvOverride;
+  return env;
 }
 
 function getBaseURLHeaders() {

--- a/src/reach-helpers/types.ts
+++ b/src/reach-helpers/types.ts
@@ -218,11 +218,11 @@ export type WalletFallbackOpts = {
 /** Algorand node override options */
 export type AlgoEnvOverride = {
   ALGO_INDEXER_PORT?: string;
-  ALGO_INDEXER_SERVER: string;
-  ALGO_INDEXER_TOKEN: string;
+  ALGO_INDEXER_SERVER?: string;
+  ALGO_INDEXER_TOKEN?: string;
   ALGO_PORT?: string;
-  ALGO_SERVER: string;
-  ALGO_TOKEN: string;
+  ALGO_SERVER?: string;
+  ALGO_TOKEN?: string;
   REACH_ISOLATED_NETWORK?: string;
 };
 


### PR DESCRIPTION
### Description
* moves dotenv use to cli/ directory
* enables token-only override in humble-sdk init-opts
* Allows users (`cli/` directory; UI; API) to supply and override token

### Links
- Relates to [SWAP-915](https://reachsh.atlassian.net/browse/SWAP-915)

### Background
`dotenv` was re-introduced in an attempt to use our AlgoNode endpoints in the SDK. This led to issues with integrating the SDK into webpack (previously reported in the SDK's early days). 

This change removes that dependency from the SDK and allows SDK users to supply their own indexer tokens. This allows other Humble properties to inject the token via `.env` variabels where needed.

### Testing
- `npm run build`
- `cd cli/`
- Add a `.env` file with the key `ALGONODE_TOKEN` (get it from me or [SWAP-915](https://reachsh.atlassian.net/browse/SWAP-915)
- `npm run test` as usual

### Notes
- Expect *lots of errors* without the token