### PR TITLE
v2.1.1-beta.0 bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reach-sh/humble-sdk",
-  "version": "2.1.0-beta.8",
+  "version": "2.1.1-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reach-sh/humble-sdk",
-      "version": "2.1.0-beta.8",
+      "version": "2.1.1-beta.0",
       "license": "ISC",
       "dependencies": {
         "@reach-sh/stdlib": "0.1.10-rc.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reach-sh/humble-sdk",
-  "version": "2.1.0-beta.8",
+  "version": "2.1.1-beta.0",
   "description": "A Javascript library for interacting with the HumbleSwap DEx",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
- Bump to `v2.1.1-beta.0`
- Introduces breaking change with `tokenBalance()` function (adds opts)