### PR TITLE
SWAP-1001

### DIFF
--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -38,12 +38,12 @@ const TK = process.env.ALGONODE_TOKEN;
 initHumbleSDK({
   network: "TestNet",
   providerEnv: { ALGO_TOKEN: TK, ALGO_INDEXER_TOKEN: TK },
-  contractOverrides: {
+  /* contractOverrides: {
     protocolId: 93443561,
     protocolAddress:
       "XSWSQVQPFMTEQO7UTXGQA5CSSYCDBT2WEN5XWNQ76EBLT2CFRV2HBYKZBE",
     partnerFarmAnnouncerId: 100474119
-  }
+  } */
 });
 
 const reach = createReachAPI();

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -38,12 +38,12 @@ const TK = process.env.ALGONODE_TOKEN;
 initHumbleSDK({
   network: "TestNet",
   providerEnv: { ALGO_TOKEN: TK, ALGO_INDEXER_TOKEN: TK },
-  /* contractOverrides: {
+  contractOverrides: {
     protocolId: 93443561,
     protocolAddress:
       "XSWSQVQPFMTEQO7UTXGQA5CSSYCDBT2WEN5XWNQ76EBLT2CFRV2HBYKZBE",
     partnerFarmAnnouncerId: 100474119
-  } */
+  }
 });
 
 const reach = createReachAPI();

--- a/cli/runAnnouncerTest.mjs
+++ b/cli/runAnnouncerTest.mjs
@@ -11,7 +11,7 @@ import {
 } from "./utils.mjs";
 
 let exitTimeout;
-const LIMIT = 10;
+let LIMIT = 10;
 const TIMEOUT = 15;
 const pools = new Set();
 
@@ -21,6 +21,10 @@ export async function runAnnouncerTest(acc) {
   Blue(`Running ANNOUNCER ${getPoolAnnouncer()}`);
   Yellow(`Attaching pool listener ...`);
   const seekNow = await answerOrDie("Start from now? (y/n)", yesno);
+
+  const hmPrompt = `Stop after how many? (Leave blank to default to 10)`
+  const howMany = (await answerOrDie(hmPrompt)) || 10
+  LIMIT = howMany
 
   subscribeToPoolStream(acc, {
     onPoolReceived: (msg) => {

--- a/cli/runFarmAnnouncerTest.mjs
+++ b/cli/runFarmAnnouncerTest.mjs
@@ -10,7 +10,7 @@ import {
 } from "./utils.mjs";
 
 let exitTimeout;
-const LIMIT = 10;
+let LIMIT = 10;
 const TIMEOUT = 15;
 
 /** Attach to farm announcer and list a subset of pools */
@@ -18,6 +18,10 @@ export async function runFarmAnnouncerTest(acc) {
   console.clear();
   Blue(`Running ANNOUNCER ${getFarmAnnouncer()}`);
   Yellow(`Attaching Farm listener ...`);
+
+  const hmPrompt = `Stop after how many? (Leave blank to default to 10)`
+  const howMany = (await answerOrDie(hmPrompt)) || 10
+  LIMIT = howMany
 
   const seekNow = await answerOrDie("Start from now? (y/n)", yesno);
   subscribeToFarmStream(acc, {

--- a/cli/runFarmAnnouncerTest.mjs
+++ b/cli/runFarmAnnouncerTest.mjs
@@ -21,6 +21,7 @@ export async function runFarmAnnouncerTest(acc) {
 
   const seekNow = await answerOrDie("Start from now? (y/n)", yesno);
   subscribeToFarmStream(acc, {
+    includePublicFarms: true,
     onFarmFetched,
     format: true,
     seekNow,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reach-sh/humble-sdk",
-  "version": "2.1.1-beta.1",
+  "version": "2.1.1-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reach-sh/humble-sdk",
-      "version": "2.1.1-beta.1",
+      "version": "2.1.1-beta.2",
       "license": "ISC",
       "dependencies": {
         "@reach-sh/stdlib": "0.1.10-rc.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reach-sh/humble-sdk",
-  "version": "2.1.1-beta.1",
+  "version": "2.1.1-beta.2",
   "description": "A Javascript library for interacting with the HumbleSwap DEx",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/api/subscribeToFarmStream.ts
+++ b/src/api/subscribeToFarmStream.ts
@@ -26,7 +26,7 @@ export type FarmSubscriptionOpts = {
   format?: boolean;
   /** When `true`, only report farms created after subscription */
   seekNow?: boolean;
-  /** When `true`, only report farms created after subscription */
+  /** When `true`, include permissionless farms */
   includePublicFarms?: boolean;
 } & ReachTxnOpts;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export type ComputeMintFn = {
   (
     addBalances: Balances,
     poolBalances: Balances,
-    lptBalances: Balances,
+    lptBalances: Balances
   ): BigNumber;
 };
 
@@ -70,7 +70,7 @@ export type ReachTxnOpts = {
 /** Options for interacting with a `Pool` contract */
 export type PoolFetchOpts = ReachTxnOpts & {
   poolAddress: string | number;
-  includeTokens?: boolean
+  includeTokens?: boolean;
 };
 
 /** Options for interacting with a `Pool` contract */
@@ -156,48 +156,48 @@ export type FetchPoolData = {
   tradeable: boolean;
 };
 
-export type StaticFarmDataUnformatted = {
-  ctcInfo: BigNumber,
-  startBlock: BigNumber,
-  endBlock: BigNumber,
-  rewardTokenId: BigNumber,
-  rewardsPerBlock: [ 
-    BigNumber, 
-    BigNumber 
-  ],
-  stakedTokenId: BigNumber,
-  pairTokenAId: Maybe<BigNumber>,
-  pairTokenASymbol: string,
-  pairTokenBId: BigNumber,
-  pairTokenBSymbol: string,
-  rewardTokenDecimals: BigNumber,
-  rewardTokenSymbol: string,
-  stakedTokenDecimals: BigNumber,
-  stakedTokenPoolId: BigNumber,
-  stakedTokenSymbol: string,
-  stakedTokenTotalSupply: BigNumber
-}
+export type FormattedRewardsPerBlock = {
+  asDefaultNetworkToken: string;
+  asRewardToken: string;
+};
 
-export type FormattedRewardsPerBlock = { asDefaultNetworkToken: string; asRewardToken: string }
+export type StaticFarmDataShared = {
+  pairTokenASymbol: string;
+  pairTokenBSymbol: string;
+  rewardTokenSymbol: string;
+  stakedTokenSymbol: string;
+  isPartnerFarm?: boolean
+};
+
+export type StaticFarmDataUnformatted = {
+  ctcInfo: BigNumber;
+  startBlock: BigNumber;
+  endBlock: BigNumber;
+  rewardTokenId: BigNumber;
+  rewardsPerBlock: [BigNumber, BigNumber];
+  stakedTokenId: BigNumber;
+  pairTokenAId: Maybe<BigNumber>;
+  pairTokenBId: BigNumber;
+  rewardTokenDecimals: BigNumber;
+  stakedTokenDecimals: BigNumber;
+  stakedTokenPoolId: BigNumber;
+  stakedTokenTotalSupply: BigNumber;
+} & StaticFarmDataShared;
 
 export type StaticFarmDataFormatted = {
-  ctcInfo: string,
-  startBlock: number,
-  endBlock: number,
-  rewardTokenId: string,
-  rewardsPerBlock: FormattedRewardsPerBlock,
-  stakedTokenId: string,
-  pairTokenAId: string,
-  pairTokenASymbol: string,
-  pairTokenBId: string,
-  pairTokenBSymbol: string,
-  rewardTokenDecimals: number,
-  rewardTokenSymbol: string,
-  stakedTokenDecimals: number,
-  stakedTokenPoolId?: string,
-  stakedTokenSymbol: string,
-  stakedTokenTotalSupply: string
-}
+  ctcInfo: string;
+  startBlock: number;
+  endBlock: number;
+  rewardTokenId: string;
+  rewardsPerBlock: FormattedRewardsPerBlock;
+  stakedTokenId: string;
+  pairTokenAId: string;
+  pairTokenBId: string;
+  rewardTokenDecimals: number;
+  stakedTokenDecimals: number;
+  stakedTokenPoolId?: string;
+  stakedTokenTotalSupply: string;
+} & StaticFarmDataShared;
 
 /**
  * @version v2


### PR DESCRIPTION
* enables subscribe-to-public-farm-stream via boolean

### Testing
- `npm run build`
- `cd cli/ && npm run test`
- Select `2` for `Farms`, then `1` to **List Farms**
- Enter `y` to "Listen from now". 
  - **Expected:** This should output two yellow warnings from the SDK; one for each enabled announcer. 
  - **Expected:** No farms will be announced, unless someone publishes one while you test (**highly** improbable)

### Notes
Invisible change: undetectable unless
- We publish some farms to the testnet announcer (I will try to make at least one) and
- The UI listens to them by using the new `includePublicFarms: true` prop in the `subscribeToFarmStream` opts. 