### PR TITLE
CLI Updates

### DIFF
--- a/cli/createTokenMedata.mjs
+++ b/cli/createTokenMedata.mjs
@@ -1,21 +1,19 @@
-import fs from 'fs'
-import { 
+import fs from "fs";
+import {
   subscribeToPoolStream,
   initHumbleSDK,
   getPoolAnnouncer,
+  getNetworkProvider,
   createReachAPI,
   fetchToken,
+  peraTokenMetadata
 } from "@reach-sh/humble-sdk";
-import {
-  Blue,
-  Green,
-  Yellow,
-  fromArgs,
-  getAccountFromArgs,
-} from "./utils.mjs";
+import { Blue, Green, Yellow, fromArgs, getAccountFromArgs } from "./utils.mjs";
 
-const tokensById = {}
-const poolIds = new Set()
+const tokensById = {};
+const poolIds = new Set();
+const tokenIds = new Set();
+let env;
 
 // Examples:
 // $ node createTokenMetadata.mjs
@@ -23,71 +21,54 @@ const poolIds = new Set()
 // $ node createTokenMetadata.mjs env=mainnet
 // $ node createTokenMetadata.mjs env=testnet
 
-const arg = fromArgs(process.argv.slice(2), "env")
-const env = ['local', 'mainnet', 'testnet'].includes(arg) ? arg : 'local'
-
-const localOpts = { network: "TestNet" }  // dev.humbleswap.com
-const mainetOpts = { network: "MainNet" }
-const testnetOpts = { 
-  network: "TestNet",
-  customTriumvirateId: 93443561,
-  customTriumvirateAddress: 'XSWSQVQPFMTEQO7UTXGQA5CSSYCDBT2WEN5XWNQ76EBLT2CFRV2HBYKZBE'
-} // testnet.humbleswap.com
-
-const opts = {
-  testnet: testnetOpts, 
-  mainnet: mainetOpts, 
-  local: localOpts
-}[env]
-
-initHumbleSDK(opts);
-const reach = createReachAPI();
-
-(async () => {
-  console.clear()
+export function createTokenMetadata(acc) {
+  const reach = createReachAPI();
   Blue(`ANNOUNCER: ${getPoolAnnouncer()}`);
-  Yellow(`Getting account ...`);
-  const args = process.argv.slice(2);
-  const acc = await getAccountFromArgs(args);
   Green(`Connected ${reach.formatAddress(acc)}\n`);
-  const onPoolFetched = makeOnPoolFetched(acc)
+
+  env = getNetworkProvider().toLowerCase();
+  if (env === "testnet" && getPoolAnnouncer() !== 93443561) env = "local";
+  Yellow(`Subscribing to "${env}" pool stream ...`);
 
   subscribeToPoolStream(acc, {
     includeTokens: true,
-    onPoolReceived: (msg) => {
-      const pAdd = msg[0]
-      poolIds.add(pAdd.toString())
+    onPoolReceived: ([pAdd, a, b]) => {
+      poolIds.add(pAdd.toString());
+      tokenIds.add(a);
+      tokenIds.add(b);
     },
-    onPoolFetched,
-  })
-})()
+    onPoolFetched: makeOnPoolFetched(acc)
+  });
+}
 
-const makeOnPoolFetched = (acc) => async ({data, succeeded, poolAddress}) => {
-  if (poolAddress) {
-    poolIds.delete(poolAddress.toString())
-  }
-  if (succeeded) {
-    const poolTok = await fetchToken(acc, data.pool.poolTokenId)
+const makeOnPoolFetched =
+  (acc) =>
+  async ({ data, succeeded, poolAddress }) => {
+    if (poolAddress) {
+      poolIds.delete(poolAddress.toString());
+    }
+    if (succeeded) {
+      const poolTok = await peraTokenMetadata(data.pool.poolTokenId, acc);
 
-    const [tokA, tokB] = data.tokens
-    if (tokA.id) tokensById[tokA.id] = tokA
-    if (tokB.id) tokensById[tokB.id] = tokB
-    if (poolTok?.id) tokensById[poolTok.id] = poolTok
-  }
+      const [tokA, tokB] = data.tokens;
+      if (tokA.id) tokensById[tokA.id] = tokA;
+      if (tokB.id) tokensById[tokB.id] = tokB;
+      if (poolTok?.id) tokensById[poolTok.id] = poolTok;
+    }
 
-  if (poolIds.size <= 0) {
-    // Convert and export
-    const jsonData = JSON.stringify(tokensById)
-    fs.writeFile(
+    if (poolIds.size <= 0) {
+      // Convert and export
+      const jsonData = JSON.stringify(tokensById);
+      fs.writeFile(
         `${env}-token-metadata.json`,
         jsonData,
-        'utf-8',
+        "utf-8",
         onEndScript
-    )
-  }
-}
+      );
+    }
+  };
 
 const onEndScript = () => {
-  Green('Token metadata exported into build directory')
-  process.exit()
-}
+  Green("Token metadata exported into build directory");
+  process.exit();
+};

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -87,7 +87,8 @@ async function main() {
   console.clear();
   // Allow overrides
   Yellow("Override HumbleSDK options? (Defaults to local testnet) [y/n]");
-  const shouldOverride = await answerOrDie("Enter y/n or press enter to skip");
+  Blue("Enter 'y' to override, or press Enter to skip");
+  const shouldOverride = await answerOrDie("Override?: (press enter to skip)");
   if (shouldOverride === "y") await overrideSDKNetwork();
 
   // Start

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -86,7 +86,7 @@ let acc;
 async function main() {
   console.clear();
   // Allow overrides
-  Yellow("Override HumbleSDK options? (Defaults to local testnet) [y/n]");
+  Yellow("Override HumbleSDK options? [y/n]");
   Blue("Enter 'y' to override, or press Enter to skip");
   const shouldOverride = await answerOrDie("Override?: (press enter to skip)");
   if (shouldOverride === "y") await overrideSDKNetwork();
@@ -107,18 +107,19 @@ async function main() {
 /** Override SDK from command line */
 async function overrideSDKNetwork() {
   Yellow("Select a network (enter option number):");
+  Blue("Press Enter to select default (testnet)");
   const doOverride = (k) => {
     humbleOpts.network = opts[k].value || "TestNet";
     if (k === 1) humbleOpts.contractOverrides = pubTestnet;
   };
   const opts = [
-    { name: "TestNet (local)", value: "TestNet" },
+    { name: "TESTNET (local - default)", value: "TestNet" },
     { name: "TestNet (public)", value: "TestNet" },
     { name: "MainNet", value: "MainNet" }
   ];
-  const prompt = await answerOrDie(
-    opts.map((o, i) => `${i + 1}. ${o.name}`).join("\n")
-  );
+  
+  opts.map(({ name }, i) => Blue(`${i + 1}. ${name}`));
+  const prompt = await answerOrDie("Enter number for selection:");
   const nPr = Number(prompt);
   if (nPr === 0) return doOverride(nPr);
   if (isNaN(nPr) || nPr > opts.length || nPr < 0) return doOverride(0);

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -107,6 +107,10 @@ async function main() {
 /** Override SDK from command line */
 async function overrideSDKNetwork() {
   Yellow("Select a network (enter option number):");
+  const doOverride = (k) => {
+    humbleOpts.network = opts[k].value || "TestNet";
+    if (k === 1) humbleOpts.contractOverrides = pubTestnet;
+  };
   const opts = [
     { name: "TestNet (local)", value: "TestNet" },
     { name: "TestNet (public)", value: "TestNet" },
@@ -115,13 +119,10 @@ async function overrideSDKNetwork() {
   const prompt = await answerOrDie(
     opts.map((o, i) => `${i + 1}. ${o.name}`).join("\n")
   );
-  const key = Number(prompt) - 1;
-  if (isNaN(key) || key >= opts.length) {
-    return exitWithMsgs("Invalid network selection. Exiting ...");
-  }
-
-  humbleOpts.network = opts[key].value || "TestNet";
-  if (key === 1) humbleOpts.contractOverrides = pubTestnet;
+  const nPr = Number(prompt);
+  if (nPr === 0) return doOverride(nPr);
+  if (isNaN(nPr) || nPr > opts.length || nPr < 0) return doOverride(0);
+  return doOverride(nPr - 1);
 }
 
 /** Select and perform an action from a list */

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -115,7 +115,7 @@ async function overrideSDKNetwork() {
     opts.map((o, i) => `${i + 1}. ${o.name}`).join("\n")
   );
   const key = Number(prompt) - 1;
-  if (isNaN(key) || key >= opts.length || key === 0) {
+  if (isNaN(key) || key >= opts.length) {
     return exitWithMsgs("Invalid network selection. Exiting ...");
   }
 

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -4,6 +4,8 @@ import {
   createReachAPI
 } from "@reach-sh/humble-sdk";
 import { loadStdlib } from "@reach-sh/stdlib";
+import { yesno } from "@reach-sh/stdlib/ask.mjs";
+import dotenv from "dotenv";
 import {
   Blue,
   Green,
@@ -26,27 +28,24 @@ import { runFetchFarmTest } from "./runFetchFarmTest.mjs";
 import { runCheckRewardsTest } from "./runCheckRewardsTest.mjs";
 import { runAnnounceFarmTest } from "./runAnnounceFarmTest.mjs";
 import { runStakeToFarmTest } from "./runStakeToFarmTest.mjs";
-import dotenv from "dotenv";
 import { runPoolReport } from "./runPoolReportTest.mjs";
 import { createFarmAnnouncer } from "./runCreateFarmAnnouncer.mjs";
 import { runCheckPartnerFarmTest } from "./runCheckPartnerFarmTest.mjs";
+import { createTokenMetadata } from "./createTokenMedata.mjs";
 
 dotenv.config({ path: "./.env" });
 
-// init SDK
 const TK = process.env.ALGONODE_TOKEN;
-initHumbleSDK({
+const humbleOpts = {
   network: "TestNet",
-  providerEnv: { ALGO_TOKEN: TK, ALGO_INDEXER_TOKEN: TK },
-  contractOverrides: {
-    protocolId: 93443561,
-    protocolAddress:
-      "XSWSQVQPFMTEQO7UTXGQA5CSSYCDBT2WEN5XWNQ76EBLT2CFRV2HBYKZBE",
-    partnerFarmAnnouncerId: 100474119
-  }
-});
+  providerEnv: { ALGO_TOKEN: TK, ALGO_INDEXER_TOKEN: TK }
+};
+const pubTestnet = {
+  protocolId: 93443561,
+  protocolAddress: "XSWSQVQPFMTEQO7UTXGQA5CSSYCDBT2WEN5XWNQ76EBLT2CFRV2HBYKZBE",
+  partnerFarmAnnouncerId: 100474119
+};
 
-const reach = createReachAPI();
 const CreateFarmAnnouncer = {
   title: "Create Farm Announcer (Requires funded account)",
   action: createFarmAnnouncer
@@ -70,7 +69,8 @@ const farmActions = [
 ];
 const tokenActions = [
   { title: "Fetch a Token", action: runFetchTokenTest },
-  { title: "Swap tokens", action: runSwapTest }
+  { title: "Swap tokens", action: runSwapTest },
+  { title: "Create JSON Metadata", action: createTokenMetadata }
 ];
 const options = [...poolActions, ...farmActions, ...tokenActions];
 const sections = [
@@ -85,14 +85,42 @@ let acc;
 /** Main script */
 async function main() {
   console.clear();
+  // Allow overrides
+  Yellow("Override HumbleSDK options? (Defaults to local testnet) [y/n]");
+  const shouldOverride = await answerOrDie("Enter y/n or press enter to skip");
+  if (shouldOverride === "y") await overrideSDKNetwork();
+
+  // Start
+  initHumbleSDK(humbleOpts);
 
   Blue(`ANNOUNCER: ${getPoolAnnouncer()}`);
   Yellow(`Getting account ...`);
+  const reach = createReachAPI();
   const args = process.argv.slice(2);
   acc = await getAccountFromArgs(args);
   Green(`Connected ${reach.formatAddress(acc)}\n`);
 
   selectAction(sections);
+}
+
+/** Override SDK from command line */
+async function overrideSDKNetwork() {
+  Yellow("Select a network (enter option number):");
+  const opts = [
+    { name: "TestNet (local)", value: "TestNet" },
+    { name: "TestNet (public)", value: "TestNet" },
+    { name: "MainNet", value: "MainNet" }
+  ];
+  const prompt = await answerOrDie(
+    opts.map((o, i) => `${i + 1}. ${o.name}`).join("\n")
+  );
+  const key = Number(prompt) - 1;
+  if (isNaN(key) || key >= opts.length || key === 0) {
+    return exitWithMsgs("Invalid network selection. Exiting ...");
+  }
+
+  humbleOpts.network = opts[key].value || "TestNet";
+  if (key === 1) humbleOpts.contractOverrides = pubTestnet;
 }
 
 /** Select and perform an action from a list */


### PR DESCRIPTION
* updates token-metadata script
* enables token metadata from cli
* enables sdk options override from cli

You can now select whether to run on local/public testnet, or mainnet from the command line. Press `Enter` to default to local testnet. 

The main change in this PR is that the **Token JSON metadata** script now uses the `peraTokenmetadata` function. This allows us to instantly update our cached files in the UI.

### Testing
- `npm run build` in the root (if you haven't done so recently)
- `cd cli && npm run test`

