### PR TITLE
SWAP-1021

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@reach-sh/stdlib": "0.1.10-rc.6",
-        "axios": "^0.27.2"
+        "axios": "^0.27.2",
+        "reach-edge": "npm:@reach-sh/stdlib@^0.1.12-rc.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.11",
@@ -3080,16 +3081,16 @@
       }
     },
     "node_modules/@randlabs/communication-bridge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@randlabs/communication-bridge/-/communication-bridge-1.0.0.tgz",
-      "integrity": "sha512-CuJNwtMTG1LHR1LQNWUPv+8xPUdkRY9p61wGJEp8J/N3q8djmnMySvSQlyVqLBvXsTPKmYc0ZmfXEXCpb5P5Cw=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@randlabs/communication-bridge/-/communication-bridge-1.0.1.tgz",
+      "integrity": "sha512-CzS0U8IFfXNK7QaJFE4pjbxDGfPjbXBEsEaCn9FN15F+ouSAEUQkva3Gl66hrkBZOGexKFEWMwUHIDKpZ2hfVg=="
     },
     "node_modules/@randlabs/myalgo-connect": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@randlabs/myalgo-connect/-/myalgo-connect-1.1.3.tgz",
-      "integrity": "sha512-iGme4YvAVCtZ6hjaEmltvd/z+Y2aIZ9s0Tw/t2WZRMD8CoWqYiDaj2vjrbtDyOarENQVNlAiY4IMpm0uI9gcUg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@randlabs/myalgo-connect/-/myalgo-connect-1.3.1.tgz",
+      "integrity": "sha512-/s+DB5Q1QMnGyPRysPQYor5CNJfQ93uVCSlgO4wEn2HRN1/NOBbi2blyEUhOZWsfNDpM/0zRuBBA8gHcnemXDg==",
       "dependencies": {
-        "@randlabs/communication-bridge": "^1.0.0"
+        "@randlabs/communication-bridge": "1.0.1"
       }
     },
     "node_modules/@reach-sh/stdlib": {
@@ -3298,36 +3299,36 @@
       "dev": true
     },
     "node_modules/@walletconnect/browser-utils": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.7.7.tgz",
-      "integrity": "sha512-6Mt7DSPaG0FKnHhuVzkU1hgtsCpGvl2nfbfRytLpyDY05iWMzMg5uK1DzV+0k4hCt9pVli0JVNt6dh9a6Xm94w==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.8.0.tgz",
+      "integrity": "sha512-Wcqqx+wjxIo9fv6eBUFHPsW1y/bGWWRboni5dfD8PtOmrihrEpOCmvRJe4rfl7xgJW8Ea9UqKEaq0bIRLHlK4A==",
       "dependencies": {
         "@walletconnect/safe-json": "1.0.0",
-        "@walletconnect/types": "^1.7.7",
+        "@walletconnect/types": "^1.8.0",
         "@walletconnect/window-getters": "1.0.0",
         "@walletconnect/window-metadata": "1.0.0",
         "detect-browser": "5.2.0"
       }
     },
     "node_modules/@walletconnect/client": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/client/-/client-1.7.7.tgz",
-      "integrity": "sha512-UuDkpXDc1Emx09aGXKz2Fg8omNp5J8ZRgNblnQTb8xnoQ8rgOJSyhbFR37PFIFwVpriZZDAgmy8HlqoGwLQ2ug==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/client/-/client-1.8.0.tgz",
+      "integrity": "sha512-svyBQ14NHx6Cs2j4TpkQaBI/2AF4+LXz64FojTjMtV4VMMhl81jSO1vNeg+yYhQzvjcGH/GpSwixjyCW0xFBOQ==",
       "dependencies": {
-        "@walletconnect/core": "^1.7.7",
-        "@walletconnect/iso-crypto": "^1.7.7",
-        "@walletconnect/types": "^1.7.7",
-        "@walletconnect/utils": "^1.7.7"
+        "@walletconnect/core": "^1.8.0",
+        "@walletconnect/iso-crypto": "^1.8.0",
+        "@walletconnect/types": "^1.8.0",
+        "@walletconnect/utils": "^1.8.0"
       }
     },
     "node_modules/@walletconnect/core": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.7.7.tgz",
-      "integrity": "sha512-XsF2x4JcBS1V2Nk/Uh38dU7ZlLmW/R5oxHp4+tVgCwTID6nZlo3vUSHBOqM7jgDRblKOHixANollm0r94bM8Cg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-aFTHvEEbXcZ8XdWBw6rpQDte41Rxwnuk3SgTD8/iKGSRTni50gI9S3YEzMj05jozSiOBxQci4pJDMVhIUMtarw==",
       "dependencies": {
-        "@walletconnect/socket-transport": "^1.7.7",
-        "@walletconnect/types": "^1.7.7",
-        "@walletconnect/utils": "^1.7.7"
+        "@walletconnect/socket-transport": "^1.8.0",
+        "@walletconnect/types": "^1.8.0",
+        "@walletconnect/utils": "^1.8.0"
       }
     },
     "node_modules/@walletconnect/crypto": {
@@ -3357,30 +3358,30 @@
       "integrity": "sha512-4BwqyWy6KpSvkocSaV7WR3BlZfrxLbJSLkg+j7Gl6pTDE+U55lLhJvQaMuDVazXYxcjBsG09k7UlH7cGiUI5vQ=="
     },
     "node_modules/@walletconnect/iso-crypto": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.7.7.tgz",
-      "integrity": "sha512-t8RKJZkFtFyWMFrl0jPz/3RAGhM5yext+MLFq3L/KTPxLgMZuT1yFHRUiV7cAN3+LcCmk6Sy/rV1yQPTiB158Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.8.0.tgz",
+      "integrity": "sha512-pWy19KCyitpfXb70hA73r9FcvklS+FvO9QUIttp3c2mfW8frxgYeRXfxLRCIQTkaYueRKvdqPjbyhPLam508XQ==",
       "dependencies": {
         "@walletconnect/crypto": "^1.0.2",
-        "@walletconnect/types": "^1.7.7",
-        "@walletconnect/utils": "^1.7.7"
+        "@walletconnect/types": "^1.8.0",
+        "@walletconnect/utils": "^1.8.0"
       }
     },
     "node_modules/@walletconnect/jsonrpc-types": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.0.tgz",
-      "integrity": "sha512-11QXNq5H1PKZk7bP8SxgmCw3HRaDuPOVE+wObqEvmhc7OWYUZqfuaaMb+OXGRSOHL3sbC+XHfdeCxFTMXSFyng==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.1.tgz",
+      "integrity": "sha512-+6coTtOuChCqM+AoYyi4Q83p9l/laI6NvuM2/AHaZFuf0gT0NjW7IX2+86qGyizn7Ptq4AYZmfxurAxTnhefuw==",
       "dependencies": {
         "keyvaluestorage-interface": "^1.0.0"
       }
     },
     "node_modules/@walletconnect/jsonrpc-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.0.tgz",
-      "integrity": "sha512-qUHbKUK6sHeHn67qtHZoLoYk5hS6x1arTPjKDRkY93/6Fx+ZmNIpdm1owX3l6aYueyegJ7mz43FpvYHUqJ8xcw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.3.tgz",
+      "integrity": "sha512-3yb49bPk16MNLk6uIIHPSHQCpD6UAo1OMOx1rM8cW/MPEAYAzrSW5hkhG7NEUwX9SokRIgnZK3QuQkiyNzBMhQ==",
       "dependencies": {
         "@walletconnect/environment": "^1.0.0",
-        "@walletconnect/jsonrpc-types": "^1.0.0"
+        "@walletconnect/jsonrpc-types": "^1.0.1"
       }
     },
     "node_modules/@walletconnect/mobile-registry": {
@@ -3405,29 +3406,29 @@
       "integrity": "sha512-QJzp/S/86sUAgWY6eh5MKYmSfZaRpIlmCJdi5uG4DJlKkZrHEF7ye7gA+VtbVzvTtpM/gRwO2plQuiooIeXjfg=="
     },
     "node_modules/@walletconnect/socket-transport": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.7.7.tgz",
-      "integrity": "sha512-RxeFkT+5BqdaZzPtPYIw6+KSVh6Q1NaYqTiAzWWh9RPuvuTajIEsi+fUXizfkpmyi9UTYBvdFXnKcB+eSImpDg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.8.0.tgz",
+      "integrity": "sha512-5DyIyWrzHXTcVp0Vd93zJ5XMW61iDM6bcWT4p8DTRfFsOtW46JquruMhxOLeCOieM4D73kcr3U7WtyR4JUsGuQ==",
       "dependencies": {
-        "@walletconnect/types": "^1.7.7",
-        "@walletconnect/utils": "^1.7.7",
+        "@walletconnect/types": "^1.8.0",
+        "@walletconnect/utils": "^1.8.0",
         "ws": "7.5.3"
       }
     },
     "node_modules/@walletconnect/types": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.7.7.tgz",
-      "integrity": "sha512-yXJrLxwLLCXtWgd/e8FjfY9v5DKds12Z7EEPzUrPSq6v7WtXpqate577KwlFQ6UYzioQzIEDE8+98j+0aiZbsw=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.8.0.tgz",
+      "integrity": "sha512-Cn+3I0V0vT9ghMuzh1KzZvCkiAxTq+1TR2eSqw5E5AVWfmCtECFkVZBP6uUJZ8YjwLqXheI+rnjqPy7sVM4Fyg=="
     },
     "node_modules/@walletconnect/utils": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.7.7.tgz",
-      "integrity": "sha512-slNlnROS4DEusGFx53hshIBylYhzd5JtGF+AJpza+Tc616+u8ozjQ9aKKUaV85bucnv5Q42bTwLYrYrXiydmuw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.8.0.tgz",
+      "integrity": "sha512-zExzp8Mj1YiAIBfKNm5u622oNw44WOESzo6hj+Q3apSMIb0Jph9X3GDIdbZmvVZsNPxWDL7uodKgZcCInZv2vA==",
       "dependencies": {
-        "@walletconnect/browser-utils": "^1.7.7",
+        "@walletconnect/browser-utils": "^1.8.0",
         "@walletconnect/encoding": "^1.0.1",
-        "@walletconnect/jsonrpc-utils": "^1.0.0",
-        "@walletconnect/types": "^1.7.7",
+        "@walletconnect/jsonrpc-utils": "^1.0.3",
+        "@walletconnect/types": "^1.8.0",
         "bn.js": "4.11.8",
         "js-sha3": "0.8.0",
         "query-string": "6.13.5"
@@ -3533,22 +3534,22 @@
       }
     },
     "node_modules/algorand-walletconnect-qrcode-modal": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/algorand-walletconnect-qrcode-modal/-/algorand-walletconnect-qrcode-modal-1.7.4.tgz",
-      "integrity": "sha512-Xj/zt4O6o3f6H8ikXX5yrwVL+/VVwTpFF4N4daHaoK/HEooAGNdkrJ7vftbjhIrs0N8+b8NUqEcMyYdaCS/CKQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/algorand-walletconnect-qrcode-modal/-/algorand-walletconnect-qrcode-modal-1.8.0.tgz",
+      "integrity": "sha512-NQgYnG0yNnyxMfiJxQtQXf3JaqcuE2dfCklugK/kWCse0JYWVAvwmAKfFZ0j597N0rU+YQTWsW+TpHroAnVfnw==",
       "dependencies": {
-        "@walletconnect/browser-utils": "^1.7.4",
+        "@walletconnect/browser-utils": "^1.8.0",
         "@walletconnect/mobile-registry": "^1.4.0",
-        "@walletconnect/types": "^1.7.4",
+        "@walletconnect/types": "^1.8.0",
         "copy-to-clipboard": "^3.3.1",
         "preact": "10.4.1",
         "qrcode": "1.4.4"
       }
     },
     "node_modules/algosdk": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-1.15.0.tgz",
-      "integrity": "sha512-541JhpsmtIh9WcEHBrRsIJhmI8IXsMan0VtCHRfZ1GvWS8CjqafqJUXxDa2kgyZx3wdm/pKin5+gt7HcmfOuaQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-1.21.0.tgz",
+      "integrity": "sha512-pgHzEExFn8hjcDphQYo+0Pi6TLWZOyXPcxjisldd6ZaaF0cNsB6C97n66OXi0gtL3mvMIgD53SLBfzy1u9YM+g==",
       "dependencies": {
         "algo-msgpack-with-bigint": "^2.1.1",
         "buffer": "^6.0.2",
@@ -3559,7 +3560,10 @@
         "json-bigint": "^1.0.0",
         "superagent": "^6.1.0",
         "tweetnacl": "^1.0.3",
-        "url-parse": "^1.5.1"
+        "vlq": "^2.0.4"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.1.2"
       }
     },
     "node_modules/ansi-escapes": {
@@ -4508,7 +4512,7 @@
     "node_modules/decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
       "engines": {
         "node": ">=0.10"
       }
@@ -5165,6 +5169,20 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+      "deprecated": "\"Please update to latest v2.3 or v2.2\"",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -6279,6 +6297,20 @@
       },
       "optionalDependencies": {
         "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/jest-jasmine2": {
@@ -8499,6 +8531,28 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/reach-edge": {
+      "name": "@reach-sh/stdlib",
+      "version": "0.1.12-rc.0",
+      "resolved": "https://registry.npmjs.org/@reach-sh/stdlib/-/stdlib-0.1.12-rc.0.tgz",
+      "integrity": "sha512-+G8CJJgBEzdLkNPdwVbsbkOCuRo5OyK4IP5YZCOANs30Rnha1IDfJBQhLVqe5SIkpomkcf9TavLg5PiiIdlSoQ==",
+      "dependencies": {
+        "@randlabs/myalgo-connect": "^1.2.0",
+        "@walletconnect/client": "^1.7.8",
+        "algorand-walletconnect-qrcode-modal": "^1.7.8-beta.1",
+        "algosdk": "^1.20.0",
+        "await-timeout": "^0.6.0",
+        "ethers": "^5.5.4",
+        "express": "^4.17.3",
+        "hi-base32": "^0.5.1",
+        "js-conflux-sdk": "git+https://github.com/reach-sh/js-conflux-sdk.git#v1_6_0_blockNumber",
+        "jsbi": "^3.1.6",
+        "node-fetch": "^2.6.1",
+        "tslib": "^2.3.1",
+        "url-parse": "^1.5.10",
+        "wait-port": "^0.2.9"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -8931,7 +8985,7 @@
     "node_modules/strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
       "engines": {
         "node": ">=4"
       }
@@ -9513,6 +9567,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/vlq": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-2.0.4.tgz",
+      "integrity": "sha512-aodjPa2wPQFkra1G8CzJBTHXhgk3EVSwxSWXNPr1fgdFLUb8kvLV1iEb6rFgasIsjP82HWI6dsb5Io26DDnasA=="
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -11900,16 +11959,16 @@
       "integrity": "sha512-rYEi46+gIzufyYUAoHDnRzkWGxajpD9vVXFQ3g1vbjrBm6P7MBmm+s/fqPa46sxa+8FOUdEuRQKaugo5a4JWpw=="
     },
     "@randlabs/communication-bridge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@randlabs/communication-bridge/-/communication-bridge-1.0.0.tgz",
-      "integrity": "sha512-CuJNwtMTG1LHR1LQNWUPv+8xPUdkRY9p61wGJEp8J/N3q8djmnMySvSQlyVqLBvXsTPKmYc0ZmfXEXCpb5P5Cw=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@randlabs/communication-bridge/-/communication-bridge-1.0.1.tgz",
+      "integrity": "sha512-CzS0U8IFfXNK7QaJFE4pjbxDGfPjbXBEsEaCn9FN15F+ouSAEUQkva3Gl66hrkBZOGexKFEWMwUHIDKpZ2hfVg=="
     },
     "@randlabs/myalgo-connect": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@randlabs/myalgo-connect/-/myalgo-connect-1.1.3.tgz",
-      "integrity": "sha512-iGme4YvAVCtZ6hjaEmltvd/z+Y2aIZ9s0Tw/t2WZRMD8CoWqYiDaj2vjrbtDyOarENQVNlAiY4IMpm0uI9gcUg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@randlabs/myalgo-connect/-/myalgo-connect-1.3.1.tgz",
+      "integrity": "sha512-/s+DB5Q1QMnGyPRysPQYor5CNJfQ93uVCSlgO4wEn2HRN1/NOBbi2blyEUhOZWsfNDpM/0zRuBBA8gHcnemXDg==",
       "requires": {
-        "@randlabs/communication-bridge": "^1.0.0"
+        "@randlabs/communication-bridge": "1.0.1"
       }
     },
     "@reach-sh/stdlib": {
@@ -12114,36 +12173,36 @@
       "dev": true
     },
     "@walletconnect/browser-utils": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.7.7.tgz",
-      "integrity": "sha512-6Mt7DSPaG0FKnHhuVzkU1hgtsCpGvl2nfbfRytLpyDY05iWMzMg5uK1DzV+0k4hCt9pVli0JVNt6dh9a6Xm94w==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.8.0.tgz",
+      "integrity": "sha512-Wcqqx+wjxIo9fv6eBUFHPsW1y/bGWWRboni5dfD8PtOmrihrEpOCmvRJe4rfl7xgJW8Ea9UqKEaq0bIRLHlK4A==",
       "requires": {
         "@walletconnect/safe-json": "1.0.0",
-        "@walletconnect/types": "^1.7.7",
+        "@walletconnect/types": "^1.8.0",
         "@walletconnect/window-getters": "1.0.0",
         "@walletconnect/window-metadata": "1.0.0",
         "detect-browser": "5.2.0"
       }
     },
     "@walletconnect/client": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/client/-/client-1.7.7.tgz",
-      "integrity": "sha512-UuDkpXDc1Emx09aGXKz2Fg8omNp5J8ZRgNblnQTb8xnoQ8rgOJSyhbFR37PFIFwVpriZZDAgmy8HlqoGwLQ2ug==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/client/-/client-1.8.0.tgz",
+      "integrity": "sha512-svyBQ14NHx6Cs2j4TpkQaBI/2AF4+LXz64FojTjMtV4VMMhl81jSO1vNeg+yYhQzvjcGH/GpSwixjyCW0xFBOQ==",
       "requires": {
-        "@walletconnect/core": "^1.7.7",
-        "@walletconnect/iso-crypto": "^1.7.7",
-        "@walletconnect/types": "^1.7.7",
-        "@walletconnect/utils": "^1.7.7"
+        "@walletconnect/core": "^1.8.0",
+        "@walletconnect/iso-crypto": "^1.8.0",
+        "@walletconnect/types": "^1.8.0",
+        "@walletconnect/utils": "^1.8.0"
       }
     },
     "@walletconnect/core": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.7.7.tgz",
-      "integrity": "sha512-XsF2x4JcBS1V2Nk/Uh38dU7ZlLmW/R5oxHp4+tVgCwTID6nZlo3vUSHBOqM7jgDRblKOHixANollm0r94bM8Cg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-aFTHvEEbXcZ8XdWBw6rpQDte41Rxwnuk3SgTD8/iKGSRTni50gI9S3YEzMj05jozSiOBxQci4pJDMVhIUMtarw==",
       "requires": {
-        "@walletconnect/socket-transport": "^1.7.7",
-        "@walletconnect/types": "^1.7.7",
-        "@walletconnect/utils": "^1.7.7"
+        "@walletconnect/socket-transport": "^1.8.0",
+        "@walletconnect/types": "^1.8.0",
+        "@walletconnect/utils": "^1.8.0"
       }
     },
     "@walletconnect/crypto": {
@@ -12173,30 +12232,30 @@
       "integrity": "sha512-4BwqyWy6KpSvkocSaV7WR3BlZfrxLbJSLkg+j7Gl6pTDE+U55lLhJvQaMuDVazXYxcjBsG09k7UlH7cGiUI5vQ=="
     },
     "@walletconnect/iso-crypto": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.7.7.tgz",
-      "integrity": "sha512-t8RKJZkFtFyWMFrl0jPz/3RAGhM5yext+MLFq3L/KTPxLgMZuT1yFHRUiV7cAN3+LcCmk6Sy/rV1yQPTiB158Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.8.0.tgz",
+      "integrity": "sha512-pWy19KCyitpfXb70hA73r9FcvklS+FvO9QUIttp3c2mfW8frxgYeRXfxLRCIQTkaYueRKvdqPjbyhPLam508XQ==",
       "requires": {
         "@walletconnect/crypto": "^1.0.2",
-        "@walletconnect/types": "^1.7.7",
-        "@walletconnect/utils": "^1.7.7"
+        "@walletconnect/types": "^1.8.0",
+        "@walletconnect/utils": "^1.8.0"
       }
     },
     "@walletconnect/jsonrpc-types": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.0.tgz",
-      "integrity": "sha512-11QXNq5H1PKZk7bP8SxgmCw3HRaDuPOVE+wObqEvmhc7OWYUZqfuaaMb+OXGRSOHL3sbC+XHfdeCxFTMXSFyng==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.1.tgz",
+      "integrity": "sha512-+6coTtOuChCqM+AoYyi4Q83p9l/laI6NvuM2/AHaZFuf0gT0NjW7IX2+86qGyizn7Ptq4AYZmfxurAxTnhefuw==",
       "requires": {
         "keyvaluestorage-interface": "^1.0.0"
       }
     },
     "@walletconnect/jsonrpc-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.0.tgz",
-      "integrity": "sha512-qUHbKUK6sHeHn67qtHZoLoYk5hS6x1arTPjKDRkY93/6Fx+ZmNIpdm1owX3l6aYueyegJ7mz43FpvYHUqJ8xcw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.3.tgz",
+      "integrity": "sha512-3yb49bPk16MNLk6uIIHPSHQCpD6UAo1OMOx1rM8cW/MPEAYAzrSW5hkhG7NEUwX9SokRIgnZK3QuQkiyNzBMhQ==",
       "requires": {
         "@walletconnect/environment": "^1.0.0",
-        "@walletconnect/jsonrpc-types": "^1.0.0"
+        "@walletconnect/jsonrpc-types": "^1.0.1"
       }
     },
     "@walletconnect/mobile-registry": {
@@ -12220,29 +12279,29 @@
       "integrity": "sha512-QJzp/S/86sUAgWY6eh5MKYmSfZaRpIlmCJdi5uG4DJlKkZrHEF7ye7gA+VtbVzvTtpM/gRwO2plQuiooIeXjfg=="
     },
     "@walletconnect/socket-transport": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.7.7.tgz",
-      "integrity": "sha512-RxeFkT+5BqdaZzPtPYIw6+KSVh6Q1NaYqTiAzWWh9RPuvuTajIEsi+fUXizfkpmyi9UTYBvdFXnKcB+eSImpDg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.8.0.tgz",
+      "integrity": "sha512-5DyIyWrzHXTcVp0Vd93zJ5XMW61iDM6bcWT4p8DTRfFsOtW46JquruMhxOLeCOieM4D73kcr3U7WtyR4JUsGuQ==",
       "requires": {
-        "@walletconnect/types": "^1.7.7",
-        "@walletconnect/utils": "^1.7.7",
+        "@walletconnect/types": "^1.8.0",
+        "@walletconnect/utils": "^1.8.0",
         "ws": "7.5.3"
       }
     },
     "@walletconnect/types": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.7.7.tgz",
-      "integrity": "sha512-yXJrLxwLLCXtWgd/e8FjfY9v5DKds12Z7EEPzUrPSq6v7WtXpqate577KwlFQ6UYzioQzIEDE8+98j+0aiZbsw=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.8.0.tgz",
+      "integrity": "sha512-Cn+3I0V0vT9ghMuzh1KzZvCkiAxTq+1TR2eSqw5E5AVWfmCtECFkVZBP6uUJZ8YjwLqXheI+rnjqPy7sVM4Fyg=="
     },
     "@walletconnect/utils": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.7.7.tgz",
-      "integrity": "sha512-slNlnROS4DEusGFx53hshIBylYhzd5JtGF+AJpza+Tc616+u8ozjQ9aKKUaV85bucnv5Q42bTwLYrYrXiydmuw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.8.0.tgz",
+      "integrity": "sha512-zExzp8Mj1YiAIBfKNm5u622oNw44WOESzo6hj+Q3apSMIb0Jph9X3GDIdbZmvVZsNPxWDL7uodKgZcCInZv2vA==",
       "requires": {
-        "@walletconnect/browser-utils": "^1.7.7",
+        "@walletconnect/browser-utils": "^1.8.0",
         "@walletconnect/encoding": "^1.0.1",
-        "@walletconnect/jsonrpc-utils": "^1.0.0",
-        "@walletconnect/types": "^1.7.7",
+        "@walletconnect/jsonrpc-utils": "^1.0.3",
+        "@walletconnect/types": "^1.8.0",
         "bn.js": "4.11.8",
         "js-sha3": "0.8.0",
         "query-string": "6.13.5"
@@ -12326,25 +12385,26 @@
       "integrity": "sha512-F1tGh056XczEaEAqu7s+hlZUDWwOBT70Eq0lfMpBP2YguSQVyxRbprLq5rELXKQOyOaixTWYhMeMQMzP0U5FoQ=="
     },
     "algorand-walletconnect-qrcode-modal": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/algorand-walletconnect-qrcode-modal/-/algorand-walletconnect-qrcode-modal-1.7.4.tgz",
-      "integrity": "sha512-Xj/zt4O6o3f6H8ikXX5yrwVL+/VVwTpFF4N4daHaoK/HEooAGNdkrJ7vftbjhIrs0N8+b8NUqEcMyYdaCS/CKQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/algorand-walletconnect-qrcode-modal/-/algorand-walletconnect-qrcode-modal-1.8.0.tgz",
+      "integrity": "sha512-NQgYnG0yNnyxMfiJxQtQXf3JaqcuE2dfCklugK/kWCse0JYWVAvwmAKfFZ0j597N0rU+YQTWsW+TpHroAnVfnw==",
       "requires": {
-        "@walletconnect/browser-utils": "^1.7.4",
+        "@walletconnect/browser-utils": "^1.8.0",
         "@walletconnect/mobile-registry": "^1.4.0",
-        "@walletconnect/types": "^1.7.4",
+        "@walletconnect/types": "^1.8.0",
         "copy-to-clipboard": "^3.3.1",
         "preact": "10.4.1",
         "qrcode": "1.4.4"
       }
     },
     "algosdk": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-1.15.0.tgz",
-      "integrity": "sha512-541JhpsmtIh9WcEHBrRsIJhmI8IXsMan0VtCHRfZ1GvWS8CjqafqJUXxDa2kgyZx3wdm/pKin5+gt7HcmfOuaQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-1.21.0.tgz",
+      "integrity": "sha512-pgHzEExFn8hjcDphQYo+0Pi6TLWZOyXPcxjisldd6ZaaF0cNsB6C97n66OXi0gtL3mvMIgD53SLBfzy1u9YM+g==",
       "requires": {
         "algo-msgpack-with-bigint": "^2.1.1",
         "buffer": "^6.0.2",
+        "fsevents": "2.1.2",
         "hi-base32": "^0.5.1",
         "js-sha256": "^0.9.0",
         "js-sha3": "^0.8.0",
@@ -12352,7 +12412,7 @@
         "json-bigint": "^1.0.0",
         "superagent": "^6.1.0",
         "tweetnacl": "^1.0.3",
-        "url-parse": "^1.5.1"
+        "vlq": "^2.0.4"
       }
     },
     "ansi-escapes": {
@@ -13096,7 +13156,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og=="
     },
     "dedent": {
       "version": "0.7.0",
@@ -13610,6 +13670,12 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -14422,6 +14488,15 @@
         "jest-worker": "^27.5.1",
         "micromatch": "^4.0.4",
         "walker": "^1.0.7"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "jest-jasmine2": {
@@ -16086,6 +16161,27 @@
         "unpipe": "1.0.0"
       }
     },
+    "reach-edge": {
+      "version": "npm:@reach-sh/stdlib@0.1.12-rc.0",
+      "resolved": "https://registry.npmjs.org/@reach-sh/stdlib/-/stdlib-0.1.12-rc.0.tgz",
+      "integrity": "sha512-+G8CJJgBEzdLkNPdwVbsbkOCuRo5OyK4IP5YZCOANs30Rnha1IDfJBQhLVqe5SIkpomkcf9TavLg5PiiIdlSoQ==",
+      "requires": {
+        "@randlabs/myalgo-connect": "^1.2.0",
+        "@walletconnect/client": "^1.7.8",
+        "algorand-walletconnect-qrcode-modal": "^1.7.8-beta.1",
+        "algosdk": "^1.20.0",
+        "await-timeout": "^0.6.0",
+        "ethers": "^5.5.4",
+        "express": "^4.17.3",
+        "hi-base32": "^0.5.1",
+        "js-conflux-sdk": "git+https://github.com/reach-sh/js-conflux-sdk.git#v1_6_0_blockNumber",
+        "jsbi": "^3.1.6",
+        "node-fetch": "^2.6.1",
+        "tslib": "^2.3.1",
+        "url-parse": "^1.5.10",
+        "wait-port": "^0.2.9"
+      }
+    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -16443,7 +16539,7 @@
     "strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -16855,6 +16951,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "vlq": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-2.0.4.tgz",
+      "integrity": "sha512-aodjPa2wPQFkra1G8CzJBTHXhgk3EVSwxSWXNPr1fgdFLUb8kvLV1iEb6rFgasIsjP82HWI6dsb5Io26DDnasA=="
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@reach-sh/stdlib": "0.1.10-rc.6",
-    "axios": "^0.27.2"
+    "axios": "^0.27.2",
+    "reach-edge": "npm:@reach-sh/stdlib@^0.1.12-rc.0"
   }
 }


### PR DESCRIPTION
* installs latest `@reach-sh/stdlib` as alternate dependency (no use yet)


### Notes
This preps the HumbleSwap ecosystem for supporting contracts on multiple versions of reach. 
- No current impact on build or build size, since the dependency is not imported or used. 
- I _did_ test importing a couple of small functions and making them available through the SDK, and there was still little impact; the bulk of the SDK's size comes from the compiled contracts. 
