### PR TITLE
2.1.1-beta.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reach-sh/humble-sdk",
-  "version": "2.1.1-beta.5",
+  "version": "2.1.1-beta.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reach-sh/humble-sdk",
-      "version": "2.1.1-beta.5",
+      "version": "2.1.1-beta.6",
       "license": "ISC",
       "dependencies": {
         "@reach-sh/stdlib": "0.1.10-rc.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reach-sh/humble-sdk",
-  "version": "2.1.1-beta.5",
+  "version": "2.1.1-beta.6",
   "description": "A Javascript library for interacting with the HumbleSwap DEx",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
* Version bump to `v2.1.1-beta.6`
* Shrinks contract artifacts