### PR TITLE
v2.1.1-beta.7 | Make file

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,0 +1,28 @@
+.PHONY: clear-screen compress
+
+ROOT_DIR := lib
+API_DIR := lib/api
+BUILD_DIR := lib/build
+JSON_DIR := lib/json
+PTCP_DIR := lib/participants
+REACH_DIR := lib/reach-helpers
+UTILS_DIR := lib/utils
+TOP_LEVEL := $(shell find $(BUILD_DIR) -name '*.js')
+MIN := uglifyjs -m -c -o
+
+clear-screen:
+	@clear
+
+compress: $(TOP_LEVEL)
+	make clear-screen
+	@echo "Compressing all JS files $(ROOT_DIR) ...\n\n"
+	@$(foreach file, $(wildcard $(ROOT_DIR)/*.js), echo "\n + Compressing $(file)"; $(MIN) $(file) -- $(file);)
+	@$(foreach file, $(wildcard $(API_DIR)/*.js), echo "\n + Compressing $(file)"; $(MIN) $(file) -- $(file);)
+	@$(foreach file, $(wildcard $(BUILD_DIR)/*.js), echo "\n + Compressing $(file)"; $(MIN) $(file) -- $(file);)
+	@$(foreach file, $(wildcard $(JSON_DIR)/*.js), echo "\n + Compressing $(file)"; $(MIN) $(file) -- $(file);)
+	@$(foreach file, $(wildcard $(PTCP_DIR)/*.js), echo "\n + Compressing $(file)"; $(MIN) $(file) -- $(file);)
+	@$(foreach file, $(wildcard $(REACH_DIR)/*.js), echo "\n + Compressing $(file)"; $(MIN) $(file) -- $(file);)
+	@$(foreach file, $(wildcard $(UTILS_DIR)/*.js), echo "\n + Compressing $(file)"; $(MIN) $(file) -- $(file);)
+	@echo 
+	@echo "All files compressed!"
+	@exit 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reach-sh/humble-sdk",
-  "version": "2.1.1-beta.6",
+  "version": "2.1.1-beta.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reach-sh/humble-sdk",
-      "version": "2.1.1-beta.6",
+      "version": "2.1.1-beta.7",
       "license": "ISC",
       "dependencies": {
         "@reach-sh/stdlib": "0.1.10-rc.6",

--- a/package.json
+++ b/package.json
@@ -12,13 +12,8 @@
     "test": "jest --watchAll --testTimeout=300000 --detectOpenHandles",
     "test:ci": "jest --testTimeout=300000",
     "compress-announcer:farm": "uglifyjs -m -c -o src/build/farmAnnouncer.large.js -- src/build/farmAnnouncer.large.js",
-    "compress-announcer:pool": "uglifyjs -m -c -o src/build/index.main.js -- src/build/index.main.js",
-    "compress-triumvirate": "uglifyjs -m -c -o src/build/index.triumvirate.js -- src/build/index.triumvirate.js",
-    "compress-n2nn": "uglifyjs -m -c -o src/build/index.net_tok.js -- src/build/index.net_tok.js",
-    "compress-nn2nn": "uglifyjs -m -c -o src/build/index.tok_tok.js -- src/build/index.tok_tok.js",
-    "compress-staker": "uglifyjs -m -c -o src/build/staker.main.js -- src/build/staker.main.js",
-    "compress-mjs": "npm run compress-announcer:farm && npm run compress-announcer:pool && npm run compress-triumvirate && npm run compress-n2nn && npm run compress-nn2nn && npm run compress-staker",
-    "build": "rm -rf lib/ && tsc",
+    "compress": "make compress",
+    "build": "rm -rf lib/ && tsc && make compress",
     "beta": "npm run build && npm publish --tag beta"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reach-sh/humble-sdk",
-  "version": "2.1.1-beta.6",
+  "version": "2.1.1-beta.7",
   "description": "A Javascript library for interacting with the HumbleSwap DEx",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "scripts": {
     "test": "jest --watchAll --testTimeout=300000 --detectOpenHandles",
     "test:ci": "jest --testTimeout=300000",
-    "compress-announcer:farm": "uglifyjs -m -c -o src/build/farmAnnouncer.large.js -- src/build/farmAnnouncer.large.js",
     "compress": "make compress",
     "build": "rm -rf lib/ && tsc && make compress",
     "beta": "npm run build && npm publish --tag beta"


### PR DESCRIPTION
* adds compression utility to post-build step

The new compression utility brings our uncompressed build down from `≈1.2MB` to `≈922KB`. 
No other code changes have been introduced.