### PR TITLE
fix fetchLiquidityPool for large mintedLiquidityTokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reach-sh/humble-sdk",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "A Javascript library for interacting with the HumbleSwap DEx",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/participants/PoolAnnouncer.test.ts
+++ b/src/participants/PoolAnnouncer.test.ts
@@ -1,0 +1,57 @@
+import { createReachAPI, initHumbleSDK } from "../index";
+import {
+  safeMintedLiquidityTokens,
+  unsafeMintedLiquidityTokens,
+} from "./PoolAnnouncer";
+
+initHumbleSDK();
+
+const mintedLiquidityTokens = "100000000000000000000000000000";
+
+const Info = jest.fn().mockImplementation(() => {
+  const bn = createReachAPI().bigNumberify;
+  return {
+    liquidityToken: bn(1),
+    lptBals: {
+      A: bn(0),
+      B: bn(mintedLiquidityTokens),
+    },
+    poolBals: {
+      A: bn(0),
+      B: bn(0),
+    },
+    protoBals: {
+      A: bn(0),
+      B: bn(0),
+    },
+    protoInfo: {
+      locked: false,
+      lpFee: 2,
+      protoAddr: "",
+      protoFee: 3,
+      totFee: 5,
+    },
+    tokA: bn(1),
+    tokB: bn(2),
+  };
+});
+
+describe.only("Fetch Liquidity Pool", () => {
+  it("Converts minted liquidity to big int as string", async () => {
+    expect(safeMintedLiquidityTokens(createReachAPI())(Info().lptBals)).toBe(
+      mintedLiquidityTokens
+    );
+  });
+});
+
+describe.only("Fetch Liquidity Pool", () => {
+  it("Unable to convert minted liquidity tokens to number", async () => {
+    expect(() => {
+      try {
+        unsafeMintedLiquidityTokens(createReachAPI())(Info().lptBals);
+      } catch (e) {
+        throw new Error(e);
+      }
+    }).toThrow("NUMERIC_FAULT")
+  });
+});


### PR DESCRIPTION
fetching liquidity pools with large minted liquidity tokens fails. Use bigNumberToBigInt instead of bigNumberToNumber as large bigNumbers will result in NUMERIC_FAULT. Also, the resulting BigInt is returned as a string.